### PR TITLE
Add type field to api-response-common-failure to avoid linter failure

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -18,7 +18,7 @@ components:
       maxLength: 32
       readOnly: true
       example: 023e105f4ecef8ad9ca31a8372d0c353
-    
+
     # API response envelopes
     result_info:
       type: object
@@ -118,6 +118,7 @@ components:
           enum:
             - null
           example: null
+          type: object
           nullable: true
     api-response-single-id:
       type: object
@@ -195,7 +196,7 @@ components:
           readOnly: true
           example: account
 
-    # Zone 
+    # Zone
     zone:
       type: object
       required:
@@ -288,7 +289,7 @@ components:
       example:
         - ns1.example.com
         - ns2.example.com
-      
+
     # User
     user:
       type: object
@@ -366,7 +367,7 @@ components:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/identifier'
+          $ref: "#/components/schemas/identifier"
         name:
           description: The plan name
           type: string
@@ -387,21 +388,21 @@ components:
           description: The frequency at which you will be billed for this plan
           type: string
           enum:
-          - weekly
-          - monthly
-          - quarterly
-          - yearly
-          - ''
+            - weekly
+            - monthly
+            - quarterly
+            - yearly
+            - ""
           readOnly: true
           example: monthly
         legacy_id:
           description: A 'friendly' identifier to indicate to the UI what plan the
             object is
           enum:
-          - free
-          - pro
-          - business
-          - enterprise
+            - free
+            - pro
+            - business
+            - enterprise
           example: pro
         is_subscribed:
           description: If the zone is subscribed to this plan
@@ -411,9 +412,9 @@ components:
           description: If the zone is allowed to subscribe to this plan
           type: boolean
           example: true
-    
+
     timestamp:
       type: string
       format: date-time
       readOnly: true
-      example: '2014-01-01T05:20:00.12345Z'
+      example: "2014-01-01T05:20:00.12345Z"


### PR DESCRIPTION
A lot of this was my linter in vscode changing things. I can remove those if you would like.