### PR TITLE
api-response-collection should use allOf

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -41,7 +41,7 @@ components:
           example: 2000
     api-response-collection:
       type: object
-      anyOf:
+      allOf:
         - $ref: "#/components/schemas/api-response-common"
         - properties:
             result:


### PR DESCRIPTION
I believe we were trying to overwrite the result field in the api-response-common, and if so, we need to use `allOf` instead of `anyOf`. 

With `anyOf` you get something weird like this
<img width="384" alt="image" src="https://user-images.githubusercontent.com/2245471/206586125-1638495e-7ce4-4060-a7bd-9d91a5153119.png">

Where I think we want it to be like this.
<img width="883" alt="image" src="https://user-images.githubusercontent.com/2245471/206586323-44916c10-556e-4728-9407-d19ba96d6a13.png">
