### PR TITLE
Fix duplicate operationid

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36756,7 +36756,7 @@ paths:
       - Stream Subtitles/Captions
       summary: Delete captions or subtitles
       description: Removes the captions or subtitles from a video.
-      operationId: stream-subtitles/-captions-delete-captions-or-subtitles
+      operationId: stream-subtitles/-captions-delete-captions-or-subtitles-by-vid
       parameters:
       - name: language
         in: path


### PR DESCRIPTION
The Cloudflare API schema has non-unique 'operationId' which does not follow the OpenAPI spec
https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.yaml
'operationId' should be unique string used to identify the operation. The id MUST be unique among all operations described in the API.

The duplicate operationId is "stream-subtitles/-captions-delete-captions-or-subtitles"

Code generators that do not follow the OpenAPI spec may not work with Cloudflare API schema.