### PR TITLE
Make api-response-single result non-null

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -139,7 +139,6 @@ components:
         - $ref: "#/components/schemas/api-response-common"
         - properties:
             result:
-              nullable: true
               anyOf:
                 - type: object
                 - type: string


### PR DESCRIPTION
There should not be an instance where an single null result is returned. This also causes issues when the schema is validated in Redocly - https://github.com/Redocly/redocly-cli/issues/925