### PR TITLE
Remove read-only attribute from UUID component

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -8,7 +8,6 @@ components:
   schemas:
     uuid:
       description: UUID
-      readOnly: true
       type: string
       maxLength: 36
       example: f174e90a-fafe-4643-bbbc-4a0ed4fc8415

--- a/common.yaml
+++ b/common.yaml
@@ -16,8 +16,12 @@ components:
       description: Identifier
       type: string
       maxLength: 32
-      readOnly: true
       example: 023e105f4ecef8ad9ca31a8372d0c353
+
+    timestamp:
+      type: string
+      format: date-time
+      example: "2014-01-01T05:20:00.12345Z"
 
     # API response envelopes
     result_info:
@@ -410,9 +414,3 @@ components:
           description: If the zone is allowed to subscribe to this plan
           type: boolean
           example: true
-
-    timestamp:
-      type: string
-      format: date-time
-      readOnly: true
-      example: "2014-01-01T05:20:00.12345Z"


### PR DESCRIPTION
The read-only attribute is prevent the UUID component from being rendered in request bodies.