### PR TITLE
message: support doc_url, l10_key, debug_message, kv_map

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -55,6 +55,18 @@ components:
               items: {}
             result_info:
               $ref: "#/components/schemas/result_info"
+    source:
+      type: object
+      properties:
+        pointer:
+          type: string
+          description: JSON Pointer [RFC6901] to the associated entity in the request document
+        parameter:
+          type: string
+          description: string indicating which URI query parameter, if any, caused the error
+        parameter_value_index:
+          type: integer
+          description: indicates position of parameter value, if any, which caused the error
     messages:
       type: array
       items:
@@ -68,6 +80,21 @@ components:
             minimum: 1000
           message:
             type: string
+            description: Error message rendered using accept-language header if provided and supported, otherwise rendered using origin server default locale
+          debug_message:
+            type: string
+            description: Error message rendered using origin server default locale if 'message' is not rendered using origin server default locale, omitted otherwise
+          l10n_key:
+            type: string
+            description: An optional key used to look up client-side locations from a map
+          doc_url:
+            type: string
+            description: An optional hyperlink to documentation about the message
+          source:
+            $ref: "#/components/schemas/source"
+          meta:
+            type: object
+            description: A freeform key/value map. Origin servers will define structure for this field in their own OpenAPI specs.
         uniqueItems: true
       example: []
 


### PR DESCRIPTION
- doc_url: a link to documentation about the erro
- l10_key: a key into a localization map
- debug_message: the error message, rendered in the the localization chosen by the origin server developer team, to facilitate debugging
- kv_map: an object whose structure is defined in the origin server's OpenAPI spec