### PR TITLE
remove `result` from `api-response-collection`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -49,10 +49,6 @@ components:
       allOf:
         - $ref: "#/components/schemas/api-response-common"
         - properties:
-            result:
-              type: array
-              nullable: true
-              items: {}
             result_info:
               $ref: "#/components/schemas/result_info"
     messages:


### PR DESCRIPTION
`result` shouldn't ever have a default value (let alone an ambiguous one!) which teams are including as part of their response objects. Instead, we'll remove this and enforce that services define their own `result` without flattening.