### PR TITLE
fix: prevent concurrent uploads

### DIFF
--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   stainless:
+    concurrency: upload-openapi-spec-action
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes:

https://github.com/cloudflare/api-schemas/actions/runs/10778361558/job/29889509703

```
Uploading spec file...
Failed to upload files: Conflict Couldn't push changes
Error: Failed to upload files: Conflict Couldn't push changes
```

By adding in a concurrency group such that no overlapping schema upload occurs. ( Github doesn't like that )