### PR TITLE
fix: add missing `type` property to `api-response-collection` schema

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -48,7 +48,8 @@ components:
       type: object
       allOf:
         - $ref: "#/components/schemas/api-response-common"
-        - properties:
+        - type: object
+          properties:
             result_info:
               $ref: "#/components/schemas/result_info"
     messages:

--- a/common.yaml
+++ b/common.yaml
@@ -24,26 +24,6 @@ components:
       example: "2014-01-01T05:20:00.12345Z"
 
     # API response envelopes
-    result_info:
-      type: object
-      properties:
-        page:
-          description: Current page within paginated list of results.
-          type: number
-          example: 1
-        per_page:
-          description: Number of results per page of results.
-          type: number
-          example: 20
-        count:
-          description: Total number of results for the requested service.
-          type: number
-          example: 1
-        total_count:
-          description: Total results available without any search parameters.
-          type: number
-          example: 2000
-
     api-response-collection:
       type: object
       allOf:
@@ -51,7 +31,25 @@ components:
         - type: object
           properties:
             result_info:
-              $ref: "#/components/schemas/result_info"
+              type: object
+              properties:
+                page:
+                  description: Current page within paginated list of results.
+                  type: number
+                  example: 1
+                per_page:
+                  description: Number of results per page of results.
+                  type: number
+                  example: 20
+                count:
+                  description: Total number of results for the requested service.
+                  type: number
+                  example: 1
+                total_count:
+                  description: Total results available without any search parameters.
+                  type: number
+                  example: 2000
+
     messages:
       type: array
       items:


### PR DESCRIPTION
- Fixes warning generated by the rule/require-type-in-schema rule