### PR TITLE
Add npm package metadata and trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -3,10 +3,16 @@ name: Publish Next
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-next-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
@@ -26,5 +32,8 @@ jobs:
           VERSION="${BASE_VERSION}-next.${DATE}.${SHA}"
           npm version "$VERSION" --no-git-tag-version
 
+      - name: Verify package contents
+        run: npm pack --dry-run
+
       - name: Publish to npm
-        run: npm publish --access public --tag next
+        run: npm publish --access public --tag next --provenance

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,30 @@
+name: Publish Next
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set next version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          DATE=$(date -u +%Y-%m-%d)
+          SHA=${GITHUB_SHA::8}
+          VERSION="${BASE_VERSION}-next.${DATE}.${SHA}"
+          npm version "$VERSION" --no-git-tag-version
+
+      - name: Publish to npm
+        run: npm publish --access public --tag next

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@cloudflare/api-schemas",
+  "version": "0.0.0",
+  "description": "OpenAPI schemas for the Cloudflare API.",
+  "license": "BSD-3-Clause",
+  "files": ["openapi.json"],
+  "main": "./openapi.json",
+  "exports": {
+    ".": "./openapi.json",
+    "./openapi.json": "./openapi.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal package.json for @cloudflare/api-schemas that exports openapi.json with version 0.0.0
- add a GitHub Actions workflow to publish next prereleases on pushes to main
- configure workflow for npm trusted publishing via OIDC (id-token: write) and use Node 24