### PR TITLE
ci(semgrep): pin contents: read on the daily scan

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 name: Semgrep config
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `semgrep.yml`, the only workflow in this repo. The workflow runs nightly inside the official `semgrep/semgrep` container and only needs read access to the checkout — semgrep findings are pushed back to Cloudflare's own Semgrep AppSec via `SEMGREP_APP_TOKEN`, not via the GitHub token.

Matches the top-level `permissions: contents: read` style already used by other cloudflare repos (e.g. `cloudflare/cloudflare-docs`, `cloudflare/pint`). YAML validated with `yaml.safe_load`.